### PR TITLE
Implement support for docker secrets for NOTIFICATION_URLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ These are quickstart instructions using Docker Compose.
     ```bash
     curl -X POST --data '{"title": "my notification title", "body": "what a great notification service!"}' localhost:5000
     ```
+
+### Using secrets
+
+If running on a docker swarm cluster [docker secrets](https://docs.docker.com/engine/swarm/secrets/) can be used to set the notification URLS to avoid leaking credentials through environment variables:
+
+1. Set up the secret with the **same** content as you would with the regular environment variable
+2. Attach the secret to the service
+3. Set the `NOTIFICATION_URLS_FILE` to the path where the secret is mounted in the service

--- a/app.py
+++ b/app.py
@@ -2,7 +2,11 @@ import apprise
 import os
 from flask import Flask, request
 
-urls = os.environ['NOTIFICATION_URLS']
+if 'NOTIFICATION_URLS' in os.environ.keys():
+    urls = os.environ['NOTIFICATION_URLS']
+elif 'NOTIFICATION_URLS_FILE' in os.environ.keys():
+    with open(os.environ['NOTIFICATION_URLS_FILE'], 'r') as secrets_file:
+        urls = secrets_file.read()
 
 apobj = apprise.Apprise()
 apobj.add(urls)


### PR DESCRIPTION
This pull request adds support for using docker secrets to set the notification urls.

Normally setting these with environment variables is leaking the credentials/tokens used in the apprise urls to anyone able to interface with docker on the host. This solves that issue.

Changes are backwards compatible, so any existing deployments shouldn't have any issues, the original environment variable based approach takes precedence if both are set.