### PR TITLE
Add deduplication feature by tracking id and state of notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,11 +13,20 @@ apobj.add(urls)
 
 app = Flask(__name__)
 
+lastMessages = dict()
+
 @app.route('/', methods=['POST'])
 def hello_world():
     data = request.get_json(force=True)
-    apobj.notify(
-        title=data['title'],
-        body=data['body'],
-    )
-    return 'ok'
+    send = True
+    if 'id' in data:
+        state = data['state'] if 'state' in data else {'title': data['title'], 'body': data['body']}
+        send = ('forceSend' in data and data['forceSend'] == 'true') or (not (data['id'] in lastMessages and lastMessages[data['id']] == state))
+        lastMessages[data['id']] = state
+
+    if send:
+        apobj.notify(
+            title=data['title'],
+            body=data['body'],
+        )
+    return 'ok' if send else 'deduplicated'


### PR DESCRIPTION
Signed-off-by: Roderik van Heijst <rvanheijst@0x0a.nl>

I came across apprise-microservice through resticker (thank you very much for both!). For our use case, I wanted resticker to inform us when a backup failed, and then inform us later if the same host made a successful backup. In other words, notify on state change - with the additional requirement that failures should always result in notifications.

This small addition to `app.py` allows one to do so (if desired) by sending an `id` field along with `body` and `title`, and optionally a `state` field. When a notification with an `id` field is received, the current `state` (either sent along or comprised out of `body` and `title`) is compared to the last state for that `id`. If the `state` is identical and there is no `forceSend` field, the microservice will not send the notification and respond with `deduplicated` instead of `ok`.

If no `id` field is sent, the microservice works as usual.

# Example without state field
```
curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup successful", "body":"body"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup successful", "body":"body"}'
deduplicated

curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup failed", "body":"body", "forceSend": "true"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup failed", "body":"body", "forceSend": "true"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup successful", "body":"body"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "title":"Backup successful", "body":"body"}'
deduplicated
```

# Example with state field
```
curl -X POST notify:5000 --data '{"id":"backup", "state": "good", "title":"Backup successful at 01:00", "body":"body"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "state": "good", "title":"Backup successful at 02:00", "body":"body"}'
deduplicated

curl -X POST notify:5000 --data '{"id":"backup", "state": "bad", "title":"Backup failed at 03:00", "body":"body", "forceSend": "true"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "state": "bad", "title":"Backup failed at 04:00", "body":"body", "forceSend": "true"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "state": "good", "title":"Backup successful at 05:00", "body":"body"}'
ok

curl -X POST notify:5000 --data '{"id":"backup", "state": "good", "title":"Backup successful at 06:00", "body":"body"}'
deduplicated
```

